### PR TITLE
Use an active fedmsg socket instead of passive ones.

### DIFF
--- a/trac_fedmsg_plugin.py
+++ b/trac_fedmsg_plugin.py
@@ -4,7 +4,6 @@ import trac.ticket.api
 import trac.wiki.api
 
 import inspect
-import socket
 import fedmsg
 
 
@@ -71,8 +70,10 @@ class FedmsgPlugin(trac.core.Component):
 
         # If fedmsg was already initialized, let's not re-do that.
         if not getattr(getattr(fedmsg, '__local', None), '__context', None):
-            hostname = socket.gethostname().split('.', 1)[0]
-            fedmsg.init(name="trac." + hostname)
+            config = fedmsg.config.load_config()
+            config['active'] = True
+            fedmsg.init(name='relay_inbound', cert_prefix='trac', **config)
+
 
     def publish(self, topic, **msg):
         """ Inner workhorse method.  Publish arguments to fedmsg. """


### PR DESCRIPTION
This will cause trac to call out to an instance of fedmsg-relay running
somewhere.

This is preferable over binding to our own sockets because trac's
component management system re-instantiates our plugin for every http
request (I didn't think it did that before...).

This should fix issue #1.
